### PR TITLE
Settings bug fix

### DIFF
--- a/YChan/Utils.cs
+++ b/YChan/Utils.cs
@@ -116,7 +116,7 @@ namespace GChan
 
             if (startWithWindows)
                 registryKey.SetValue(PROGRAM_NAME, '"' + Application.ExecutablePath + '"' + " -tray");
-            else
+            else if (registryKey.GetValue(PROGRAM_NAME) != null)
                 registryKey.DeleteValue(PROGRAM_NAME);
         }
 


### PR DESCRIPTION
Fixes bug that didn't allow the user to save and close the settings window if the registry key didn't exist.
GChan would not execute any code after Utils.SaveSettings(); because of this

Also, you have issues disabled in the repository settings