### PR TITLE
Save post number in ImageLink, for ease of use in GenerateNewFilename

### DIFF
--- a/GChan/Forms/AboutBox.resx
+++ b/GChan/Forms/AboutBox.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -123,6 +123,7 @@ https://github.com/Issung/GChan
 
 List of contributers to GChan (Thank you!)
  - MistressAshai
+ - RoyalJackal
 
 YChan updated by Ricardo1991 and FugiMuffi at
 https://github.com/Ricardo1991/YChan

--- a/GChan/ImageLink.cs
+++ b/GChan/ImageLink.cs
@@ -5,12 +5,16 @@ namespace GChan
 {
     public class ImageLink
     {
+        /// <summary>
+        /// For 4chan: Unix timestamp with microseconds at which the image was uploaded.
+        /// For 8kun: The ID of the post this image belongs to (same as No).
+        /// </summary>
         public long Tim;
 
         /// <summary>
         /// URL to the access the image.
         /// </summary>
-        public string URL;
+        public string Url;
 
         /// <summary>
         /// The filename the image was uploaded with. 
@@ -18,26 +22,26 @@ namespace GChan
         /// </summary>
         public string UploadedFilename;
 
-        public ImageLink(string url, string uploadedFilename)
-        {
-            URL = url;
-            UploadedFilename = uploadedFilename;
-        }
+        /// <summary>
+        /// The ID of the post this image belongs to.
+        /// </summary>
+        public long No;
 
-        public ImageLink(long tim, string url, string uploadedFilename)
+        public ImageLink(long tim, string url, string uploadedFilename, long no)
         {
             Tim = tim;
-            URL = url;
+            Url = url;
             UploadedFilename = uploadedFilename;
+            No = no;
         }
 
-        public string GenerateNewFilename(ImageFileNameFormat format)
+        public string GenerateFilename(ImageFileNameFormat format)
         {
             //const int FILENAME_MAX_LENGTH = 254;
-            string[] parts = URL.Split('/');
-            string lastPart = (parts.Length > 0) ? parts.Last() : URL;
+            string[] parts = Url.Split('/');
+            string lastPart = (parts.Length > 0) ? parts.Last() : Url;
 
-            string extension = Path.GetExtension(URL); // Contains period (.).
+            string extension = Path.GetExtension(Url); // Contains period (.).
 
             string result;
 
@@ -51,7 +55,7 @@ namespace GChan
                     break;
                 case ImageFileNameFormat.IDAndOriginalFilename:
                 default:
-                    result = Path.GetFileNameWithoutExtension(URL) + " - " + UploadedFilename + extension;
+                    result = Path.GetFileNameWithoutExtension(Url) + " - " + UploadedFilename + extension;
                     break;
             }
 
@@ -65,11 +69,11 @@ namespace GChan
             }
             else if (format == ImageFileNameFormat.IDAndOriginalFilename)
             {
-                result = Path.GetFileNameWithoutExtension(URL) + " - " + UploadedFilename + extension;
+                result = Path.GetFileNameWithoutExtension(Url) + " - " + UploadedFilename + extension;
             }
             else //ImageFileFormat == OriginalFilenameAndID
             {
-                result = UploadedFilename + " - " + Path.GetFileNameWithoutExtension(URL) + extension;
+                result = UploadedFilename + " - " + Path.GetFileNameWithoutExtension(Url) + extension;
             }
 
             //if (result.Length > FILENAME_MAX_LENGTH)
@@ -84,7 +88,7 @@ namespace GChan
 
         public override string ToString()
         {
-            return $"ImageLink {{ Tim: '{Tim}', URL: '{URL}', UploadedFilename: '{UploadedFilename}' }}";
+            return $"ImageLink {{ Tim: '{Tim}', Url: '{Url}', UploadedFilename: '{UploadedFilename}', No: '{No}' }}";
         }
     }
 }

--- a/GChan/Trackers/Sites/Thread_4Chan.cs
+++ b/GChan/Trackers/Sites/Thread_4Chan.cs
@@ -62,10 +62,10 @@ namespace GChan.Trackers
                     .SelectTokens("posts[*]")
                     .Where(x => x["ext"] != null)
                     .Select(x =>
-                        new ImageLink(long.Parse(x[timPath].ToString()),
+                        new ImageLink(x[timPath].Value<long>(),
                             baseURL + x[timPath] + x["ext"],
                             x["filename"].ToString(),
-                            long.Parse(x["no"].ToString())))
+                            x["no"].Value<long>()))
                     .ToList();
             }
             catch (Exception ex)
@@ -116,10 +116,10 @@ namespace GChan.Trackers
 
                     //get the actual filename saved
                     string filename = Path.GetFileNameWithoutExtension(
-                        new ImageLink(long.Parse(post["tim"].ToString()),
+                        new ImageLink(post["tim"].Value<long>(),
                                 old,
                                 post["filename"].ToString(),
-                                long.Parse(post["no"].ToString()))
+                                post["no"].Value<long>())
                             .GenerateFilename((ImageFileNameFormat)Settings.Default.ImageFilenameFormat));
 
                     //Save thumbs for files that need it

--- a/GChan/Trackers/Sites/Thread_4Chan.cs
+++ b/GChan/Trackers/Sites/Thread_4Chan.cs
@@ -64,7 +64,8 @@ namespace GChan.Trackers
                     .Select(x =>
                         new ImageLink(long.Parse(x[timPath].ToString()),
                             baseURL + x[timPath] + x["ext"],
-                            x["filename"].ToString()))
+                            x["filename"].ToString(),
+                            long.Parse(x["no"].ToString())))
                     .ToList();
             }
             catch (Exception ex)
@@ -115,9 +116,11 @@ namespace GChan.Trackers
 
                     //get the actual filename saved
                     string filename = Path.GetFileNameWithoutExtension(
-                        new ImageLink(old,
-                            post["filename"].ToString())
-                            .GenerateNewFilename((ImageFileNameFormat)Settings.Default.ImageFilenameFormat));
+                        new ImageLink(long.Parse(post["tim"].ToString()),
+                                old,
+                                post["filename"].ToString(),
+                                long.Parse(post["no"].ToString()))
+                            .GenerateFilename((ImageFileNameFormat)Settings.Default.ImageFilenameFormat));
 
                     //Save thumbs for files that need it
                     if (replacement.Split('.')[1] == "webm")

--- a/GChan/Trackers/Sites/Thread_8Kun.cs
+++ b/GChan/Trackers/Sites/Thread_8Kun.cs
@@ -59,7 +59,7 @@ namespace GChan.Trackers
                 }
 
                 // Get the numbers of replies that have 1 or more images.
-                var nos = jObject.SelectTokens("posts[?(@.tim)].no").Select(x => long.Parse(x.ToString())).ToList();
+                var nos = jObject.SelectTokens("posts[?(@.tim)].no").Select(x => x.Value<long>()).ToList();
 
                 // Loop through each reply.
                 foreach (var no in nos)

--- a/GChan/Trackers/Sites/Thread_8Kun.cs
+++ b/GChan/Trackers/Sites/Thread_8Kun.cs
@@ -79,7 +79,7 @@ namespace GChan.Trackers
                                 Fpath1Url(tims[j], exts[j]); // "1"
 
                             // Save image link using reply no (number) as tim because 8kun tims have letters and numbers in them. The reply number will work just fine.
-                            links.Add(new ImageLink(no, url, filenames[j]));
+                            links.Add(new ImageLink(no, url, filenames[j], no));
                         }
                     }
                 }

--- a/GChan/Utils.cs
+++ b/GChan/Utils.cs
@@ -197,12 +197,12 @@ namespace GChan
                 Directory.CreateDirectory(dir);
             }
 
-            string destFilepath = CombinePathAndFilename(dir, link.GenerateNewFilename((ImageFileNameFormat)Settings.Default.ImageFilenameFormat));
+            string destFilepath = CombinePathAndFilename(dir, link.GenerateFilename((ImageFileNameFormat)Settings.Default.ImageFilenameFormat));
 
             try
             {
                 using var webClient = new WebClient();
-                webClient.DownloadFile(link.URL, destFilepath);
+                webClient.DownloadFile(link.Url, destFilepath);
 
                 // TODO: Figure out how to make the async downloading work properly.
                 // This line is currently not working and downloads 0 byte files 100% of the time.
@@ -219,7 +219,7 @@ namespace GChan
             }
             catch (WebException ex)
             {
-                logger.Error(ex, $"Error occured while downloading link {link.URL}.");
+                logger.Error(ex, $"Error occured while downloading link {link.Url}.");
                 return false;
             }
         }


### PR DESCRIPTION
For the 8kun currently post id is being saved into the Tim variable as the actual tim is a string of some sort. Maybe Tim variable should be made into string so both 8kun and 4chan tims would be stored as strings?