### PR TITLE
Add pending column to main screen, addressing issue #51

### DIFF
--- a/GChan/Forms/MainForm.Designer.cs
+++ b/GChan/Forms/MainForm.Designer.cs
@@ -60,6 +60,7 @@ namespace GChan.Forms
             threadGridBoardCodeColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             Id = new System.Windows.Forms.DataGridViewTextBoxColumn();
             threadGridFileCountColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            threadGridPendingCountColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             threadsContextMenu = new System.Windows.Forms.ContextMenuStrip(components);
             openFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             openInBrowserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -298,7 +299,7 @@ namespace GChan.Forms
             threadGridView.BackgroundColor = System.Drawing.Color.White;
             threadGridView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             threadGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            threadGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { threadGridSubjectColumn, threadGridSiteColumn, threadGridBoardCodeColumn, Id, threadGridFileCountColumn });
+            threadGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { threadGridSubjectColumn, threadGridSiteColumn, threadGridBoardCodeColumn, Id, threadGridFileCountColumn, threadGridPendingCountColumn });
             threadGridView.ContextMenuStrip = threadsContextMenu;
             threadGridView.DataSource = threadsBindingSource;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
@@ -364,10 +365,18 @@ namespace GChan.Forms
             // threadGridFileCountColumn
             // 
             threadGridFileCountColumn.DataPropertyName = "FileCount";
-            threadGridFileCountColumn.FillWeight = 8.387236F;
+            threadGridFileCountColumn.FillWeight = 10F;
             threadGridFileCountColumn.HeaderText = "File Count";
             threadGridFileCountColumn.Name = "threadGridFileCountColumn";
             threadGridFileCountColumn.ReadOnly = true;
+            //
+            // threadGridPendingCountColumn
+            //
+            threadGridPendingCountColumn.DataPropertyName = "PendingCount";
+            threadGridPendingCountColumn.FillWeight = 9F;
+            threadGridPendingCountColumn.HeaderText = "Pending";
+            threadGridPendingCountColumn.Name = "threadGridPendingCountColumn";
+            threadGridPendingCountColumn.ReadOnly = true;
             // 
             // threadsContextMenu
             // 
@@ -731,6 +740,7 @@ namespace GChan.Forms
         private System.Windows.Forms.DataGridViewTextBoxColumn threadGridBoardCodeColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn Id;
         private System.Windows.Forms.DataGridViewTextBoxColumn threadGridFileCountColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn threadGridPendingCountColumn;
         private System.Windows.Forms.ToolStripMenuItem resumeDownloadsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pauseDownloadsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resumeDownloadsToolStripMenuItem1;

--- a/GChan/Forms/MainForm.resx
+++ b/GChan/Forms/MainForm.resx
@@ -132,6 +132,9 @@
   <metadata name="threadGridFileCountColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="PendingCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="threadsContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>113, 17</value>
   </metadata>

--- a/GChan/Models/Trackers/Thread.cs
+++ b/GChan/Models/Trackers/Thread.cs
@@ -76,6 +76,19 @@ namespace GChan.Models.Trackers
             }
         }
 
+        public int PendingCount
+        {
+            get => SeenAssetIds
+                    .Where(id => id.Type == AssetType.Upload)
+                    .Except(SavedAssetIds)                    
+                    .Count();
+        }
+
+        public void NotifyPendingCountChanged()
+        {
+            MainForm.StaticInvoke(() => NotifyPropertyChanged(nameof(PendingCount)));
+        }
+
         public bool Gone { get; protected set; } = false;
 
         /// <summary>
@@ -141,6 +154,7 @@ namespace GChan.Models.Trackers
             FileCount = results.Uploads.Length;
             SeenAssetIds.AddRange(newAssets);
             Priority = ProcessPriority.Default; // Set priority to default. May have been set to "high" if thread was new.
+            this.NotifyPendingCountChanged();
 
             return new(removeFromQueue: false, newProcessables: newAssets);
         }

--- a/GChan/Models/Upload.cs
+++ b/GChan/Models/Upload.cs
@@ -94,6 +94,7 @@ namespace GChan.Models
             await Utils.WriteFileBytesAsync(path, fileBytes, cancellationToken);
 
             Thread.SavedAssetIds.Add(Id);
+            Thread.NotifyPendingCountChanged();
 
             return new(removeFromQueue: true);
         }


### PR DESCRIPTION
My take on viewing download progress.
Added a new column to the main screen to show the pending count. This would be the number of files that were found during scraping, but not yet downloaded.

![image](https://github.com/user-attachments/assets/e4f1278f-91b9-4e16-8b7d-5c820b3e3494)


Implementation notes:
* The count is not stored/maintained, it is computed from seen (scraped) and downloaded sets. This should reflect the internal state accurately and cover edge cases like posts being deleted before being downloaded. It is essentially the number of files planned to be downloaded.
* Updating the UI is explicitly invoked in places where the list is being updated. This approach could miss updates if in future versions the lists are updated in a new place and the UI is not. But the alternative would be adding some observability on ConcurrentHashSet, which would be a bigger task.