### PR TITLE
Add functionality to save and delete boards and threads in the database

### DIFF
--- a/GChan/Controllers/MainController.cs
+++ b/GChan/Controllers/MainController.cs
@@ -1,4 +1,4 @@
-﻿using GChan.Data;
+using GChan.Data;
 using GChan.Forms;
 using GChan.Helpers;
 using GChan.Models;
@@ -203,6 +203,10 @@ namespace GChan.Controllers
                         Model.Boards.Add(board);
                     });
                 }
+                if (Settings.Default.SaveListsOnClose)
+                {
+                    DataController.SaveBoard(board);
+                }
             }
             else if (tracker is Thread thread)
             {
@@ -212,6 +216,10 @@ namespace GChan.Controllers
                     {
                         Model.Threads.Add(thread);
                     });
+                }
+                if (Settings.Default.SaveListsOnClose)
+                {
+                    DataController.SaveThread(thread);
                 }
             }
 
@@ -324,6 +332,10 @@ namespace GChan.Controllers
                     });
 
                     board.GreatestThreadId = greatestThreadId;
+                    if (Settings.Default.SaveListsOnClose)
+                    {
+                        DataController.SaveBoard(board);
+                    }
                 }
             }
 
@@ -416,6 +428,10 @@ namespace GChan.Controllers
                     Model.Boards.Remove(board);
                 });
             }
+            if (Settings.Default.SaveListsOnClose)
+            {
+                DataController.DeleteBoard(board.Url);
+            }
         }
 
         public void SettingsUpdated()
@@ -456,6 +472,10 @@ namespace GChan.Controllers
                     {
                         Model.Threads.Remove(thread);
                     });
+                }
+                if (Settings.Default.SaveListsOnClose)
+                {
+                    DataController.DeleteThread(thread.Url);
                 }
             }
             catch (Exception ex)

--- a/GChan/Data/DataController.cs
+++ b/GChan/Data/DataController.cs
@@ -1,4 +1,4 @@
-﻿using GChan.Trackers;
+using GChan.Trackers;
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
@@ -138,6 +138,53 @@ namespace GChan.Data
         {
             SaveThreads(threads);
             SaveBoards(boards);
+        }
+
+        /// <summary>
+        /// Persists a single thread to the database (insert or replace).
+        /// </summary>
+        public static void SaveThread(Thread thread)
+        {
+            using var cmd = new SQLiteCommand(Connection);
+            cmd.CommandText = $@"INSERT OR REPLACE INTO {TB_THREAD} ({COL_URL}, {COL_SUBJECT}, {COL_SAVED_IDS}) VALUES (@{COL_URL}, @{COL_SUBJECT}, @{COL_SAVED_IDS})";
+            cmd.Parameters.AddWithValue(COL_URL, thread.Url);
+            cmd.Parameters.AddWithValue(COL_SUBJECT, thread.Subject);
+            cmd.Parameters.AddWithValue(COL_SAVED_IDS, thread.SavedIds.ToStringList());
+            cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Removes a single thread from the database by URL.
+        /// </summary>
+        public static void DeleteThread(string url)
+        {
+            using var cmd = new SQLiteCommand(Connection);
+            cmd.CommandText = $"DELETE FROM {TB_THREAD} WHERE {COL_URL} = @{COL_URL}";
+            cmd.Parameters.AddWithValue(COL_URL, url);
+            cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Persists a single board to the database (insert or replace).
+        /// </summary>
+        public static void SaveBoard(Board board)
+        {
+            using var cmd = new SQLiteCommand(Connection);
+            cmd.CommandText = $@"INSERT OR REPLACE INTO {TB_BOARD} ({COL_URL}, {COL_GREATEST_THREAD_ID}) VALUES (@{COL_URL}, @{COL_GREATEST_THREAD_ID})";
+            cmd.Parameters.AddWithValue(COL_URL, board.Url);
+            cmd.Parameters.AddWithValue(COL_GREATEST_THREAD_ID, board.GreatestThreadId);
+            cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Removes a single board from the database by URL.
+        /// </summary>
+        public static void DeleteBoard(string url)
+        {
+            using var cmd = new SQLiteCommand(Connection);
+            cmd.CommandText = $"DELETE FROM {TB_BOARD} WHERE {COL_URL} = @{COL_URL}";
+            cmd.Parameters.AddWithValue(COL_URL, url);
+            cmd.ExecuteNonQuery();
         }
 
         public static void SaveThreads(IList<Thread> threads)


### PR DESCRIPTION
Implemented methods in DataController to persist and remove boards and threads. Updated MainController to call these methods based on user settings for saving lists on close.

When "Save URLs on exit" option is toggled, threads only persist on graceful exit. However if the process is killed, all the threads are lost. This change allows threads to persist without relying on a graceful exit, but instead saves them into the database on every addition/deletion